### PR TITLE
Node Multiversion Packaging

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -42,7 +42,6 @@ jobs:
         node-version: [16, 18, 20]
     with:
       INITCONTAINER_LANGUAGE: nodejs
-      INITCONTAINER_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.node-version }}
       TEST_APP_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.node-version }}
 
   publish:
@@ -50,13 +49,5 @@ jobs:
     needs: test
     uses: ./.github/workflows/publish.yml
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [16, 18, 20]
     with:
       INITCONTAINER_LANGUAGE: nodejs
-      DOCKER_IMAGE_TAG_SUFFIX: nodejs${{ matrix.node-version }}x
-      DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX: ${{ matrix.node-version == 20 }}
-      BUILD_ARGS: |
-        RUNTIME_VERSION=${{ matrix.node-version }}

--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -6,9 +6,7 @@
 #   Then in the second stage, copy the directory to `/instrumentation`.
 # - Ensure you have `newrelic`, and`@newrelic/native-metrics`.
 # - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
-ARG RUNTIME_VERSION=20
-
-FROM node:${RUNTIME_VERSION} AS build
+FROM node:20 AS build_node20
 
 WORKDIR /instrumentation
 
@@ -17,9 +15,34 @@ ARG AGENT_VERSION=latest
 RUN npm install newrelic@${AGENT_VERSION}
 
 # copy instrumentation file
-COPY newrelicinstrumentation.js .
+COPY newrelicinstrumentation_nodeversion.js newrelicinstrumentation.js
+
+FROM node:18 AS build_node18
+
+WORKDIR /instrumentation
+
+# Install dependencies
+ARG AGENT_VERSION=latest
+RUN npm install newrelic@${AGENT_VERSION}
+
+# copy instrumentation file
+COPY newrelicinstrumentation_nodeversion.js newrelicinstrumentation.js
+
+FROM node:16 AS build_node16
+
+WORKDIR /instrumentation
+
+# Install dependencies
+ARG AGENT_VERSION=latest
+RUN npm install newrelic@${AGENT_VERSION}
+
+# copy instrumentation file
+COPY newrelicinstrumentation_nodeversion.js newrelicinstrumentation.js
 
 # initcontainer
 FROM busybox
-COPY --from=build /instrumentation /instrumentation
+COPY --from=build_node20 /instrumentation /instrumentation/node20x
+COPY --from=build_node18 /instrumentation /instrumentation/node18x
+COPY --from=build_node16 /instrumentation /instrumentation/node16x
+COPY newrelicinstrumentation_root.js /instrumentation/newrelicinstrumentation.js
 RUN chmod -R go+r /instrumentation

--- a/src/nodejs/newrelicinstrumentation.js
+++ b/src/nodejs/newrelicinstrumentation.js
@@ -1,1 +1,0 @@
-require('newrelic')

--- a/src/nodejs/newrelicinstrumentation_nodeversion.js
+++ b/src/nodejs/newrelicinstrumentation_nodeversion.js
@@ -1,0 +1,1 @@
+require('newrelic')

--- a/src/nodejs/newrelicinstrumentation_root.js
+++ b/src/nodejs/newrelicinstrumentation_root.js
@@ -1,0 +1,7 @@
+try {
+    // Try to import the correct package based on the major version of NodeJS
+    const node_version = process.versions.node.split(".")[0];
+    require('./node' + node_version + "x/newrelicinstrumentation.js")
+} catch (error) {
+    console.error(error)
+}

--- a/tests/nodejs/Dockerfile
+++ b/tests/nodejs/Dockerfile
@@ -4,6 +4,5 @@ FROM node:${RUNTIME_VERSION}
 WORKDIR /app
 
 COPY index.js .
-RUN npm install newrelic@latest --verbose
 
-CMD ["node", "-r", "newrelic", "index.js"]
+CMD ["node", "index.js"]


### PR DESCRIPTION
## Overview

* Upgrade NodeJS agent packaging to mirror multiversion packaging done for Python agent.
* Remove package installs from test app to be sure the correct agent is used.