### PR TITLE
chore(deps): bump eclipse-temurin in /tests/java

### DIFF
--- a/tests/java/Dockerfile
+++ b/tests/java/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM eclipse-temurin:17-jdk-jammy as build
+FROM eclipse-temurin:21-jdk-jammy as build
 
 # Install git
 RUN apt update
@@ -13,7 +13,7 @@ RUN cd ./spring-petclinic && git checkout 923e2b7aa331b8194a6579da99fb6388f15d7f
 RUN cd ./spring-petclinic && ./mvnw -Dmaven.test.skip=true clean package
 
 # PRODUCTION STAGE
-FROM eclipse-temurin:17-jre-jammy as production
+FROM eclipse-temurin:21-jre-jammy as production
 
 # Create work directory
 WORKDIR /petclinic-app


### PR DESCRIPTION
DO NOT MERGE

Testing if this triggers a successful e2e run on https://github.com/newrelic/newrelic-agent-init-container/pull/47 since dependabot can't access the required secrets.

Bumps eclipse-temurin from 17-jre-jammy to 21-jre-jammy.

---
updated-dependencies:
- dependency-name: eclipse-temurin dependency-type: direct:production ...