### PR TITLE
Fix Node Image Name

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,6 +59,7 @@ jobs:
         node-version: [16, 18, 20]
     with:
       INITCONTAINER_LANGUAGE: nodejs
+      DOCKER_IMAGE_NAME: newrelic/newrelic-node-init
       DOCKER_IMAGE_TAG_SUFFIX: nodejs${{ matrix.node-version }}x
       DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX: ${{ matrix.node-version == 20 }}
       BUILD_ARGS: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: ""
       DOCKER_IMAGE_NAME:
-        description: "Name for the published docker image, defaults to newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init"
+        description: "Name for the published docker image, defaults to newrelic/newrelic-<INITCONTAINER_LANGUAGE>-init"
         required: false
         type: string
         default: ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ""
+      DOCKER_IMAGE_NAME:
+        description: "Name for the published docker image, defaults to newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init"
+        required: false
+        type: string
+        default: "newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init"
       DOCKER_IMAGE_TAG_SUFFIX:
         description: "Suffix to append to all version tags. (string with no preceding -)"
         required: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ on:
         description: "Name for the published docker image, defaults to newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init"
         required: false
         type: string
-        default: "newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init"
+        default: ""
       DOCKER_IMAGE_TAG_SUFFIX:
         description: "Suffix to append to all version tags. (string with no preceding -)"
         required: false
@@ -65,7 +65,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # 5.5.1
         with:
-          images: newrelic/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init
+          images: ${{ inputs.DOCKER_IMAGE_NAME || format('newrelic/newrelic-{0}-init', inputs.INITCONTAINER_LANGUAGE) }}
           flavor: |
             latest=false
           tags: ${{ steps.version.outputs.tags }}


### PR DESCRIPTION
* Fixes an issue where NodeJS's initcontainer name was `newrelic/newrelic-nodejs-init` instead of `newrelic/newrelic-node-init`.