### PR TITLE
Modify the .NET helm chart to allow passing a value for NEW_RELIC_HOST

### DIFF
--- a/tests/dotnet/chart/templates/deployment.yaml
+++ b/tests/dotnet/chart/templates/deployment.yaml
@@ -32,9 +32,8 @@ spec:
             value: finest
           - name: NEW_RELIC_LOG_CONSOLE
             value: "1"
-          # set the host to staging if using a staging license key
-          #- name: NEW_RELIC_HOST
-          #  value: staging-collector.newrelic.com
+          - name: NEW_RELIC_HOST
+            value: {{ .Values.newRelicHost | default "collector.newrelic.com" }}
 ---
 apiVersion: v1
 kind: Service

--- a/tests/dotnet/chart/values.yaml
+++ b/tests/dotnet/chart/values.yaml
@@ -1,1 +1,2 @@
 scenarioTag: ""
+newRelicHost: ""


### PR DESCRIPTION
Updates the helm chart for .NET testing to allow the (optional) passing of a value for the `NEW_RELIC_HOST` environment variable.  

The .NET team needs this to accommodate local testing, using our own staging license key. The value defaults to `collector.newrelic.com` so will continue to work correctly in the e2e tests. 

(Note that the .NET team can't use the existing `Makefile`, as it's not Windows-friendly. No big deal though; I've documented the manual steps we need to run.)