### PR TITLE
ci: Added Node 22 to the Node.js workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, 22]
     with:
       INITCONTAINER_LANGUAGE: nodejs
       INITCONTAINER_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.node-version }}
@@ -62,11 +62,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, 22]
     with:
       INITCONTAINER_LANGUAGE: nodejs
       DOCKER_IMAGE_NAME: newrelic/newrelic-node-init
       DOCKER_IMAGE_TAG_SUFFIX: nodejs${{ matrix.node-version }}x
-      DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX: ${{ matrix.node-version == 20 }}
+      DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX: ${{ matrix.node-version == 22 }}
       BUILD_ARGS: |
         RUNTIME_VERSION=${{ matrix.node-version }}


### PR DESCRIPTION
With 11.22.0+ we support Node.js 22. This PR updates the workflow to include this runtime version.  

###  Links
Closes [NR-286240](https://new-relic.atlassian.net/browse/NR-286240)

[NR-286240]: https://new-relic.atlassian.net/browse/NR-286240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ