### PR TITLE
Makefile Scripting Upgrades

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,30 +31,41 @@ cert-manager:
 
 # Install official k8s-agents-operator repo
 .PHONY: operator
-operator: cert-manager
+operator: cert-manager license_key_secret
 	helm uninstall k8s-agents-operator --ignore-not-found
 	helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
 	helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
-		--namespace=default \
+		--create-namespace \
+		--namespace=k8s-agents-operator \
 		--set=licenseKey=${NEW_RELIC_LICENSE_KEY} \
 		--set=controllerManager.manager.image.tag=edge
 	sleep 1
-	kubectl wait --for=condition=Ready -n default --all pods
+	kubectl wait --for=condition=Ready -n k8s-agents-operator --all pods
 
 # Build and install local copy of k8s-agents-operator
-
 .PHONY: operator-local
-operator-local:
-	minikube image build ${LOCAL_OPERATOR_REPO_PATH}/ -t e2e/k8s-agents-operator:e2e
+operator-local: license_key_secret
+	eval $$(minikube docker-env --shell=bash) && \
+		docker build ${LOCAL_OPERATOR_REPO_PATH}/ -t e2e/k8s-agents-operator:e2e
 	helm uninstall k8s-agents-operator --ignore-not-found
 	sleep 1
-	helm upgrade --install k8s-agents-operator ${LOCAL_OPERATOR_REPO_PATH}/charts/k8s-agents-operator/ --namespace=default \
+	helm upgrade --install k8s-agents-operator ${LOCAL_OPERATOR_REPO_PATH}/charts/k8s-agents-operator/ \
+		--create-namespace \
+		--namespace=k8s-agents-operator \
 		--set=licenseKey=${NEW_RELIC_LICENSE_KEY} \
 		--set=controllerManager.manager.image.pullPolicy=Never \
 		--set=controllerManager.manager.image.repository=e2e/k8s-agents-operator \
 		--set=controllerManager.manager.image.tag=e2e
 	sleep 1
-	kubectl wait --for=condition=Ready -n default --all pods
+	kubectl wait --for=condition=Ready -n k8s-agents-operator --all pods
+
+# Set license key in default namespace
+.PHONY: license_key_secret
+license_key_secret:
+	kubectl delete secret newrelic-key-secret --ignore-not-found
+	kubectl create secret generic newrelic-key-secret \
+		--from-literal="new_relic_license_key=${NEW_RELIC_LICENSE_KEY}" \
+		-n default
 
 # Build local initcontainer image
 .PHONY: build-initcontainer
@@ -89,7 +100,7 @@ logs-testapp:
 # View test app container logs
 .PHONY: logs-testapp
 logs-operator:
-	kubectl logs $$(kubectl get pods -n default | grep k8s-agents-operator | cut -d" " -f1)
+	kubectl logs -n k8s-agents-operator $$(kubectl get pods -n k8s-agents-operator | grep k8s-agents-operator | cut -d" " -f1)
 
 .PHONY: check-language-arg
 check-language-arg:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,12 +70,14 @@ license_key_secret:
 # Build local initcontainer image
 .PHONY: build-initcontainer
 build-initcontainer: check-language-arg
-	minikube image build -t e2e/newrelic-${INITCONTAINER_LANGUAGE}-init:e2e ${REPO_ROOT}/src/${INITCONTAINER_LANGUAGE}/
+	eval $$(minikube docker-env --shell=bash) && \
+		docker build -t e2e/newrelic-${INITCONTAINER_LANGUAGE}-init:e2e ${REPO_ROOT}/src/${INITCONTAINER_LANGUAGE}/
 
 # Build local test app image
 .PHONY: build-testapp
 build-testapp: check-language-arg
-	minikube image build -t e2e/test-app-${INITCONTAINER_LANGUAGE}:e2e ${REPO_ROOT}/tests/${INITCONTAINER_LANGUAGE}/
+	eval $$(minikube docker-env --shell=bash) && \
+		docker build -t e2e/test-app-${INITCONTAINER_LANGUAGE}:e2e ${REPO_ROOT}/tests/${INITCONTAINER_LANGUAGE}/
 
 # Deploy and open test app in browser
 .PHONY: test


### PR DESCRIPTION
* Update Makefile scripting with some improvements.
  * Separate operator namespace from test app namespace to prevent issues where the wait condition was waiting forever on the wrong item.
  * Change `minikube image build` to `docker build` to avoid issues where image builds fail silently and don't stop the script from continuing.