### PR TITLE
chore: Removed support for Node.js 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [18, 20, 22]
     with:
       INITCONTAINER_LANGUAGE: nodejs
       INITCONTAINER_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.node-version }}
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [18, 20, 22]
     with:
       INITCONTAINER_LANGUAGE: nodejs
       DOCKER_IMAGE_NAME: newrelic/newrelic-node-init


### PR DESCRIPTION
This PR removes publishing versions of Node.js agent on 16. We are about to release an agent that no longer supports it and this will avoid creating a broken Node.js 16 Images.

Closes NR-285151
