### PR TITLE
Add Azure e2e tests for Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ on:
 permissions: read-all
 
 jobs:
-  test:
-    name: Run E2E tests for ${{ inputs.INITCONTAINER_LANGUAGE }}
+  kubernetes:  
+    name: Run Kubernetes E2E tests for ${{ inputs.INITCONTAINER_LANGUAGE }}
     runs-on: ubuntu-latest
 
     steps:
@@ -89,6 +89,83 @@ jobs:
           retry_attempts: 5
           agent_enabled: false
           spec_path: tests/${{ inputs.INITCONTAINER_LANGUAGE }}/test-specs.yml
+          account_id: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          api_key: ${{ secrets.NEW_RELIC_API_KEY }}
+          license_key: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+
+  # This is currently only enabled for Python.
+  # Once other teams complete work on init containers
+  # the language conditional can be removed 
+  azure:
+    name: Run Azure E2E tests for Python 
+    runs-on: ubuntu-latest
+    if: ${{ inputs.INITCONTAINER_LANGUAGE }} == "python"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
+        with:
+          persist-credentials: false
+
+      - name: Extract Agent Version from Release Tag
+        id: version
+        if: github.event_name == 'release'
+        run: |
+          echo AGENT_VERSION=$(echo "${{ github.ref_name }}" | sed -e "s/^v//g" -e "s/_[a-zA-Z]*//g" -e "s/\.[0-9]*$//g") | tee -a ${GITHUB_ENV}
+
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+    
+      - name: Log in to Azure Container Registry (ACR)
+        uses: docker/login-action@v3
+        with:
+          registry: e2eazure.azurecr.io
+          username: ${{ secrets.AZURE_CREDENTIALS.clientId }} # If this doesn't work, enter manually
+          password: ${{ secrets.AZURE_CREDENTIALS.clientSecret }} # If this doesn't work, enter manually
+
+      - name: Build and push Docker images to ACR
+        run: |
+          BUILD_ARGS=${{ inputs.TEST_APP_BUILD_ARGS }}
+          if [[ -n "${BUILD_ARGS}" ]]; then BUILD_ARGS="--build-arg=${BUILD_ARGS}"; fi
+          docker build --tag test-app-${{ inputs.INITCONTAINER_LANGUAGE }}-init tests/${{ inputs.INITCONTAINER_LANGUAGE }}/ --platform linux/amd64 ${BUILD_ARGS}
+          docker tag test-app-${{ inputs.INITCONTAINER_LANGUAGE }} e2eazure.azurecr.io/test-app-${{ inputs.INITCONTAINER_LANGUAGE }}:e2e
+          docker push e2eazure.azurecr.io/test-app-${{ inputs.INITCONTAINER_LANGUAGE }}:e2e
+          if [[ -n "${{ env.AGENT_VERSION }}" ]]; then BUILD_ARGS="${BUILD_ARGS:-} --build-arg=AGENT_VERSION=${{ env.AGENT_VERSION }}"; fi
+          docker build --tag newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init src/${{ inputs.INITCONTAINER_LANGUAGE }}/ --platform linux/amd64 ${BUILD_ARGS}
+          docker tag newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init e2eazure.azurecr.io/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init:e2e
+          docker push e2eazure.azurecr.io/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init:e2e
+
+      - name: Azure CLI script to create license-key secrets
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az containerapp secret set --name cli-test-container-app --resource-group cli-test-rg --secrets license-key=${{ secrets.NEW_RELIC_LICENSE_KEY }}
+
+      - name: Build and deploy Container App
+        uses: azure/container-apps-deploy-action@v1
+        with:
+          #appSourcePath: tests/${{ inputs.INITCONTAINER_LANGUAGE }}/
+          #dockerfilePath: tests.${{ inputs.INITCONTAINER_LANGUAGE }}.Dockerfile
+          containerAppName: cli-test-container-app
+          acrName: e2eazure
+          imageToBuild: e2eazure.azurecr.io/test-app-${{ inputs.INITCONTAINER_LANGUAGE }}:e2e
+          resourceGroup: cli-test-rg
+          containerAppEnvironment: cli-test-env
+          builderStack: alpine-bookworm   # verify that this works
+          yamlConfigPath: ${{ github.workspace }}/tests/${{ inputs.INITCONTAINER_LANGUAGE }}/template_file.yaml
+    
+      - name: Run e2e-test for Azure
+        uses: newrelic/newrelic-integration-e2e-action@fd53fc95e287dcd7b5bd86a4a25d653aadf407d0  # 1.11.1
+        # Skip e2e tests for dependabot PRs since dependabot can't access secrets
+        if: github.actor != 'dependabot[bot]'
+        with:
+          retry_seconds: 60
+          retry_attempts: 5
+          agent_enabled: false
+          spec_path: tests/${{ inputs.INITCONTAINER_LANGUAGE }}/test-azure.yml
           account_id: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           api_key: ${{ secrets.NEW_RELIC_API_KEY }}
           license_key: ${{ secrets.NEW_RELIC_LICENSE_KEY }}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 # Constants
 MAKEFILE_DIR:=$(dir $(realpath $(firstword ${MAKEFILE_LIST})))
 REPO_ROOT:=$(realpath ${MAKEFILE_DIR}../)
+TEMPLATE_FILE:=$(realpath ${MAKEFILE_DIR})/${INITCONTAINER_LANGUAGE}/template_file.yaml
 
 # Initcontainer language under test
 INITCONTAINER_LANGUAGE:=${INITCONTAINER_LANGUAGE}
@@ -12,9 +13,17 @@ LOCAL_OPERATOR_REPO_PATH:=${REPO_ROOT}/../k8s-agents-operator
 .PHONY: default
 default: all
 
-# Install all dependencies and run tests
+# Install all dependencies and run all tests
 .PHONY: all
-all: minikube cert-manager operator test
+all: all-k8s all-azure 
+
+# Install all Kubernetes dependencies and run tests
+.PHONY: all-k8s
+all-k8s: minikube cert-manager k8s-operator k8s-test
+
+# Install all Azure dependencies and run tests
+.PHONY: all-azure
+all-azure: azure-env deploy-azure-images azure-container-app license_key_env_vars-azure template-file-upload 
 
 # Start minikube
 .PHONY: minikube
@@ -30,8 +39,8 @@ cert-manager:
 	kubectl wait --for=condition=Ready -n cert-manager --all pods --timeout=60s
 
 # Install official k8s-agents-operator repo
-.PHONY: operator
-operator: cert-manager license_key_secret
+.PHONY: k8s-operator
+k8s-operator: cert-manager license_key_secret-k8s
 	helm uninstall k8s-agents-operator --ignore-not-found
 	helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
 	helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
@@ -43,8 +52,8 @@ operator: cert-manager license_key_secret
 	kubectl wait --for=condition=Ready -n k8s-agents-operator --all pods
 
 # Build and install local copy of k8s-agents-operator
-.PHONY: operator-local
-operator-local: license_key_secret
+.PHONY: k8s-operator-local
+k8s-operator-local: license_key_secret-k8s
 	eval $$(minikube docker-env --shell=bash) && \
 		docker build ${LOCAL_OPERATOR_REPO_PATH}/ -t e2e/k8s-agents-operator:e2e
 	helm uninstall k8s-agents-operator --ignore-not-found
@@ -60,28 +69,28 @@ operator-local: license_key_secret
 	kubectl wait --for=condition=Ready -n k8s-agents-operator --all pods
 
 # Set license key in default namespace
-.PHONY: license_key_secret
-license_key_secret:
+.PHONY: license_key_secret-k8s
+license_key_secret-k8s:
 	kubectl delete secret newrelic-key-secret --ignore-not-found
 	kubectl create secret generic newrelic-key-secret \
 		--from-literal="new_relic_license_key=${NEW_RELIC_LICENSE_KEY}" \
 		-n default
 
-# Build local initcontainer image
-.PHONY: build-initcontainer
-build-initcontainer: check-language-arg
+# Build local Kubernetes initcontainer image
+.PHONY: build-k8s-initcontainer
+build-k8s-initcontainer: check-language-arg
 	eval $$(minikube docker-env --shell=bash) && \
 		docker build -t e2e/newrelic-${INITCONTAINER_LANGUAGE}-init:e2e ${REPO_ROOT}/src/${INITCONTAINER_LANGUAGE}/
 
-# Build local test app image
-.PHONY: build-testapp
-build-testapp: check-language-arg
+# Build local Kubernetes test app image
+.PHONY: build-k8s-testapp
+build-k8s-testapp: check-language-arg
 	eval $$(minikube docker-env --shell=bash) && \
 		docker build -t e2e/test-app-${INITCONTAINER_LANGUAGE}:e2e ${REPO_ROOT}/tests/${INITCONTAINER_LANGUAGE}/
 
-# Deploy and open test app in browser
-.PHONY: test
-test: build-initcontainer build-testapp check-language-arg
+# Deploy and open Kubernetes test app in browser
+.PHONY: k8s-test
+k8s-test: build-k8s-initcontainer build-k8s-testapp check-language-arg
 	helm uninstall test-deployment --ignore-not-found
 	sleep 1
 	helm install test-deployment ${REPO_ROOT}/tests/${INITCONTAINER_LANGUAGE}/chart/
@@ -89,20 +98,75 @@ test: build-initcontainer build-testapp check-language-arg
 	kubectl wait --for=condition=Ready -n default --all pods
 	minikube service test-app-${INITCONTAINER_LANGUAGE}-service -n default
 
-# View test app container logs
+# View Kubernetes test app container logs
 .PHONY: get-pods
 get-pods:
 	kubectl get pods -n default
 
-# View test app container logs
-.PHONY: logs-testapp
-logs-testapp:
+# View Kubernetes test app container logs
+.PHONY: k8s-logs-testapp
+k8s-logs-testapp:
 	kubectl logs $$(kubectl get pods -n default | grep test-app- | cut -d" " -f1)
 
-# View test app container logs
-.PHONY: logs-testapp
-logs-operator:
+# View Kubernetes test app container logs
+.PHONY: k8s-logs-testapp
+k8s-logs-operator:
 	kubectl logs -n k8s-agents-operator $$(kubectl get pods -n k8s-agents-operator | grep k8s-agents-operator | cut -d" " -f1)
+
+
+# Set up Azure environment, shared volume, and container registry
+.PHONY: azure-env
+azure-env:
+	az login
+	az group create --name cli-test-rg --location westus
+	az containerapp env create --name cli-test-env --resource-group cli-test-rg --location westus
+	az storage account create --resource-group cli-test-rg --name testcliappstorageaccount --location westus --kind StorageV2 --sku Standard_LRS --enable-large-file-share
+	az storage share-rm create --resource-group cli-test-rg --storage-account testcliappstorageaccount --name testfilesharecli --quota 4096 --enabled-protocols SMB
+	az containerapp env storage set --access-mode ReadWrite --azure-file-account-name testcliappstorageaccount --azure-file-account-key `az storage account keys list -n testcliappstorageaccount --query "[0].value" -o tsv --resource-group cli-test-rg` --azure-file-share-name testfilesharecli --storage-name instrumentation --name cli-test-env --resource-group cli-test-rg
+	az acr create --resource-group cli-test-rg --name e2eazure --sku Standard --location westus --admin-enabled true
+	az acr login --resource-group cli-test-rg --name e2eazure
+	
+# Build local Azure initcontainer image
+.PHONY: build-azure-initcontainer
+build-azure-initcontainer: check-language-arg
+	docker build --tag newrelic-${INITCONTAINER_LANGUAGE}-init ${REPO_ROOT}/src/${INITCONTAINER_LANGUAGE}/ --platform linux/amd64
+
+# Build local Azure test app image
+.PHONY: build-azure-testapp
+build-azure-testapp: check-language-arg
+	docker build --tag test-app-${INITCONTAINER_LANGUAGE} ${REPO_ROOT}/tests/${INITCONTAINER_LANGUAGE}/ --platform linux/amd64
+
+# Deploy Azure test apps and init container
+.PHONY: deploy-azure-images
+deploy-azure-images: build-azure-initcontainer build-azure-testapp check-language-arg
+	docker tag newrelic-${INITCONTAINER_LANGUAGE}-init e2eazure.azurecr.io/newrelic-${INITCONTAINER_LANGUAGE}-init:e2e
+	docker push e2eazure.azurecr.io/newrelic-${INITCONTAINER_LANGUAGE}-init:e2e
+	docker tag test-app-${INITCONTAINER_LANGUAGE} e2eazure.azurecr.io/test-app-${INITCONTAINER_LANGUAGE}:e2e
+	docker push e2eazure.azurecr.io/test-app-${INITCONTAINER_LANGUAGE}:e2e
+
+# Create container app
+.PHONY: azure-container-app
+azure-container-app: check-language-arg
+	az containerapp create --name cli-test-container-app --resource-group cli-test-rg --environment cli-test-env --image e2eazure.azurecr.io/test-app-${INITCONTAINER_LANGUAGE}:e2e --min-replicas 1 --max-replicas 1 --target-port 8000 --ingress external --registry-server e2eazure.azurecr.io
+
+# Set license key as a secret and set other environment variables
+.PHONY: license_key_env_vars-azure
+license_key_env_vars-azure:
+	az containerapp secret set --name cli-test-container-app --resource-group cli-test-rg --secrets license-key=${NEW_RELIC_LICENSE_KEY} 
+	# For testing, we will keep this as NEW_RELIC_K8S_OPERATOR_ENABLED, but right before releasing the Python Agent, we will change this to NEW_RELIC_AZURE_OPERATOR_ENABLED
+	az containerapp update --name cli-test-container-app --resource-group cli-test-rg --set-env-vars "NEW_RELIC_HOST=staging-collector.newrelic.com" "NEW_RELIC_APP_NAME=Azure-E2E-tests" "NEW_RELIC_K8S_OPERATOR_ENABLED=true" "NEW_RELIC_LICENSE_KEY=secretref:license-key" "PYTHONPATH=/mnt/instrumentation"
+
+# Update container app with new configuration
+# This will use template file to do so
+.PHONY: template-file-upload
+template-file-upload:
+	az containerapp update --name cli-test-container-app --resource-group cli-test-rg --yaml ${TEMPLATE_FILE}
+
+# Delete the resource group and everything in it
+.PHONY: azure-delete
+azure-delete:
+	az group delete --name cli-test-rg --yes --no-wait true
+
 
 .PHONY: check-language-arg
 check-language-arg:

--- a/tests/python/template_file.yaml
+++ b/tests/python/template_file.yaml
@@ -1,0 +1,71 @@
+location: West US
+name: cli-test-container-app
+properties:
+  configuration:
+    activeRevisionsMode: Single
+    ingress:
+      allowInsecure: false
+      exposedPort: 0
+      external: true
+      targetPort: 8000
+      traffic:
+      - latestRevision: true
+        weight: 100
+      transport: Auto
+    maxInactiveRevisions: 100
+    registries:
+    - identity: ''
+      passwordSecretRef: e2eazureazurecrio-e2eazure
+      server: e2eazure.azurecr.io
+      username: e2eazure
+    secrets:
+    - name: e2eazureazurecrio-e2eazure
+    - name: license-key
+  template:
+    containers:
+    - env:
+      #      - name: NEW_RELIC_HOST
+      #        value: staging-collector.newrelic.com
+      - name: NEW_RELIC_APP_NAME
+        value: Azure-E2E-tests
+      - name: NEW_RELIC_K8S_OPERATOR_ENABLED
+        value: 'true'
+      - name: PYTHONPATH
+        value: /mnt/instrumentation
+      - name: NEW_RELIC_LICENSE_KEY
+        secretRef: license-key
+      image: e2eazure.azurecr.io/test-app-python:e2e
+      name: cli-test-container-app
+      resources:
+        cpu: 2
+        ephemeralStorage: 4Gi
+        memory: 4Gi
+      volumeMounts:
+      - mountPath: /mnt/instrumentation
+        volumeName: instrumentation
+    initContainers:
+    - args:
+      - -c
+      - cp -r /instrumentation /mnt/
+      command:
+      - /bin/sh
+      image: e2eazure.azurecr.io/newrelic-python-init:e2e
+      name: nr-init-container
+      resources:
+        cpu: 2
+        ephemeralStorage: 4Gi
+        memory: 4Gi
+      volumeMounts:
+      - mountPath: /mnt/instrumentation
+        volumeName: instrumentation
+    revisionSuffix: ''
+    scale:
+      maxReplicas: 1
+      minReplicas: 1
+    volumes:
+    - name: instrumentation
+      storageName: instrumentation
+      storageType: AzureFile
+  workloadProfileName: Consumption
+resourceGroup: cli-test-rg
+type: Microsoft.App/containerApps

--- a/tests/python/test-azure.yml
+++ b/tests/python/test-azure.yml
@@ -1,0 +1,12 @@
+description: End-to-end tests for python initcontainer in Azure
+scenarios:
+  - description: This scenario will verify that a transaction is reported by the test app after a curl request
+    before:
+      - sleep 300
+      - curl https://`az containerapp show --name cli-test-container-app --resource-group cli-test-rg --query properties.configuration.ingress.fqdn | cut -d'"' -f2` 
+    tests:
+      nrqls:
+        - query: SELECT latest(duration) AS duration FROM Transaction WHERE appName = 'Azure-E2E-tests'
+          expected_results:
+            - key: "duration"
+              lowerBoundedValue: 0.0


### PR DESCRIPTION
The Azure Container Apps service is able to utilize the same init container in this repo.  This PR adds end-to-end testing for the usage of this init container in Azure Container Apps