### PR TITLE
Fix for Ruby tests

### DIFF
--- a/tests/ruby/Gemfile
+++ b/tests/ruby/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 
-gem "rackup", "~> 2.1"
+gem 'rackup', '~> 2.2'
+gem 'webrick'


### PR DESCRIPTION
On November 2, 2024, Ruby library `rackup` released a new version going from v2.1 to v2.2 and despite the minor version bump decided to drop a library dependency on (Ruby web server) `webrick`. We now explicitly declare the `webrick` dependency in our own `Gemfile` manifest.