### PR TITLE
Update dotnet Dockerfile to .NET 9

### DIFF
--- a/tests/dotnet/Dockerfile
+++ b/tests/dotnet/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build
 WORKDIR /src
 RUN dotnet new webapi --name WeatherForecast --output ./
 RUN dotnet publish -o /app/publish


### PR DESCRIPTION
.NET 9 went GA last week and we want to start using it here.