### PR TITLE
ci: Skip Docker Hub login for Dependot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
       # Gives higher rate limits for image pulls
       - name: Login to Docker Hub Container Registry (Read Only)
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # 3.3.0
+        # skip login for workflows triggered by Dependabot 
+        if: github.actor != 'dependabot[bot]' 
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN_READ_ONLY }}


### PR DESCRIPTION
Skips the Docker container registry login when a workflow is triggered by Dependabot.