### PR TITLE
ci: Add a workflow to manually run e2e tests for all languages

### DIFF
--- a/.github/workflows/all_e2e_tests.yml
+++ b/.github/workflows/all_e2e_tests.yml
@@ -1,0 +1,24 @@
+# Copyright New Relic, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: "Run tests for all languages"
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  test-dotnet:
+    uses: ./.github/workflows/dotnet.yml
+  test-java:
+    uses: ./.github/workflows/java.yml
+  test-nodejs:
+    uses: ./.github/workflows/nodejs.yml
+  test-python:
+    uses: ./.github/workflows/python.yml
+  test-php:
+    uses: ./.github/workflows/php.yml
+  test-ruby:
+    uses: ./.github/workflows/ruby.yml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,6 +33,7 @@ on:
   release:
     types:
       - published
+  workflow_call:
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -33,6 +33,7 @@ on:
   release:
     types:
       - published
+  workflow_call:
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,8 @@ on:
   release:
     types:
       - published
-
+  workflow_call:
+    
 env:
   INITCONTAINER_LANGUAGE: nodejs
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,6 +33,7 @@ on:
   release:
     types:
       - published
+  workflow_call:
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,6 +33,7 @@ on:
   release:
     types:
       - published
+  workflow_call:
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,7 @@ on:
   release:
     types:
       - published
+  workflow_call:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Adds a new workflow that can (only) be triggered manually, which will run E2E tests for all languages. 

Intended to be used in conjunction with Dependabot PRs -- someone will need to kick off this workflow on the Dependabot PR branch and verify that it runs successfully before approving and merging the Dependabot PR. 