### PR TITLE
Updates all busybox references to use `stable` instead of `latest`

### DIFF
--- a/src/dotnet/Dockerfile
+++ b/src/dotnet/Dockerfile
@@ -24,6 +24,6 @@ RUN /dotnet-agent-download.sh $TARGETARCH $AGENT_VERSION
 # replace agentinfo.json from the tarball with one that identifies this as a k8s-operator install type
 COPY agentinfo.json .
 
-FROM busybox:latest@sha256:db142d433cdde11f10ae479dbf92f3b13d693fd1c91053da9979728cceb1dc68 
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/java/Dockerfile
+++ b/src/java/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /java-agent-download.sh
 ARG AGENT_VERSION
 RUN /java-agent-download.sh $AGENT_VERSION
 
-FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 COPY --from=build /newrelic-agent.jar /newrelic-agent.jar
 # Set executable permissions on Java agent jar file
 RUN chmod -R go+r /newrelic-agent.jar

--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -20,6 +20,6 @@ RUN npm install newrelic@${AGENT_VERSION}
 COPY newrelicinstrumentation.js .
 
 # initcontainer
-FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/php/Dockerfile
+++ b/src/php/Dockerfile
@@ -14,6 +14,6 @@ RUN rm php-agent-download.sh
 RUN mkdir php-agent php-agent/bin php-agent/ext php-agent/ini php-agent/logs
 COPY newrelic.ini ./php-agent/ini/
 
-FROM busybox:latest@sha256:82742949a3709938cbeb9cec79f5eaf3e48b255389f2dcedf2de29ef96fd841c
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -29,7 +29,7 @@ RUN cp ./workspace/newrelic/newrelic/bootstrap/sitecustomize.py ./workspace/site
 COPY newrelic_k8s_operator.py ./workspace/
 
 # Package Init Container
-FROM busybox:latest@sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 
 COPY --from=build /operator-build/workspace /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/ruby/Dockerfile
+++ b/src/ruby/Dockerfile
@@ -12,7 +12,7 @@ ARG AGENT_VERSION
 ADD Gemfile .
 RUN BUNDLE_PATH=workspace bundle install
 
-FROM busybox:latest@sha256:db142d433cdde11f10ae479dbf92f3b13d693fd1c91053da9979728cceb1dc68
+FROM busybox:stable@sha256:7c3c3cea5d4d6133d6a694d23382f6a7b32652f23855abdba3eb039ca5995447
 
 # Copy build artifacts from previous
 COPY --from=build /operator-build /operator-build


### PR DESCRIPTION
In an effort to reduce the frequency of Dependabot PRs (and based on a good idea from @nrcventura), this PR updates all `busybox` references to use the `stable` tag instead of `latest`.  The digest was updated to reference the [multi-platform busybox image for the `stable` tag](https://hub.docker.com/layers/library/busybox/stable/images/sha256-afa67e3cea50ce204060a6c0113bd63cb289cc0f555d5a80a3bb7c0f62b95add).