### PR TITLE
Update test instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
             --namespace=default \
             --set=licenseKey=${{ secrets.NEW_RELIC_LICENSE_KEY }} \
-            --set=controllerManager.manager.image.tag=${{ inputs.K8S_OPERATOR_IMAGE_TAG }}
+            --set=controllerManager.manager.image.version=${{ inputs.K8S_OPERATOR_IMAGE_TAG }}
           sleep 5
           kubectl wait --for=condition=Ready -n default --all pods
 

--- a/README.md
+++ b/README.md
@@ -71,23 +71,19 @@ export NEW_RELIC_LICENSE_KEY=***
 ```bash
 make -f tests/Makefile minikube
 ```
-3. Install [cert-manager](https://cert-manager.io/).
-```bash
-make -f tests/Makefile cert-manager
-```
-4. Install the New Relic [Kubernetes Agents Operator](https://github.com/newrelic/k8s-agents-operator/)
+3. Install the New Relic [Kubernetes Agents Operator](https://github.com/newrelic/k8s-agents-operator/)
 ```bash
 make -f tests/Makefile operator
 ```
-5. Build a local copy of the init container in minikube.
+4. Build a local copy of the init container in minikube.
 ```bash
 make -f tests/Makefile build-initcontainer
 ```
-6. Build a local copy of the test app in minikube.
+5. Build a local copy of the test app in minikube.
 ```bash
 make -f tests/Makefile build-testapp
 ```
-7. Deploy the test app instrumented with the init container. A browser window will open if the deployment succeeds.
+6. Deploy the test app instrumented with the init container. A browser window will open if the deployment succeeds.
 ```bash
 make -f tests/Makefile test
 ```

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,7 +45,7 @@ operator-local:
 		--set=newRelicHost=${NEW_RELIC_HOST} \
 		--set=controllerManager.manager.image.pullPolicy=Never \
 		--set=controllerManager.manager.image.repository=e2e/k8s-agents-operator \
-		--set=controllerManager.manager.image.tag=e2e
+		--set=controllerManager.manager.image.version=e2e
 	sleep 5
 	kubectl wait --for=condition=Ready pods $$(kubectl get pods | grep k8s-agents-operator | cut -d" " -f1)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,7 +29,7 @@ operator:
 	helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
 	helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
 		--set=licenseKey=${NEW_RELIC_LICENSE_KEY} \
-		--set=controllerManager.manager.image.tag=edge
+		--set=controllerManager.manager.image.version=edge
 	sleep 5
 	kubectl wait --for=condition=Ready pods $$(kubectl get pods | grep k8s-agents-operator | cut -d" " -f1)
 


### PR DESCRIPTION
- Installing cert manager no a longer relevant step. Removed from Makefile in #117 
- Key changed from tag -> version - [source](https://github.com/newrelic/k8s-agents-operator/blob/main/charts/k8s-agents-operator/README.md?plain=1#L283)