### PR TITLE
Add Arch Specific Tests for Python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,9 +47,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        architecture: ["linux/amd64", "linux/arm64"]
     with:
       INITCONTAINER_LANGUAGE: python
       INITCONTAINER_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.python-version }}-alpine
+      ARCHITECTURE: ${{ matrix.architecture }}
       TEST_APP_BUILD_ARGS: RUNTIME_VERSION=${{ matrix.python-version }}
 
   publish:

--- a/tests/python/test-specs.yml
+++ b/tests/python/test-specs.yml
@@ -14,6 +14,7 @@ scenarios:
       # Ensure initcontainer was attached by operator
       - kubectl get pods --output yaml | yq '.items[].spec.initContainers[].name' | grep -q "nri-python--test-app-python" || { echo -e "===== Operator failed to attach initcontainer. =====" >&2; exit 1; }
       # Send traffic to test app to generate transactions
+      - sleep 10
       - curl --fail-with-body $(minikube service test-app-python-service --url -n default)
     tests:
       nrqls:


### PR DESCRIPTION
# Overview

* Add specific tests for all supported docker architectures for the Python agent.
  * Preventing issues like this [failed NodeJS release](https://github.com/newrelic/newrelic-agent-init-container/actions/runs/16531257674) that didn't catch the removal of 32-bit ARM linux support from the base docker image.