### PR TITLE
Add Longer sleep for NodeJS Tests

### DIFF
--- a/tests/nodejs/test-specs.yml
+++ b/tests/nodejs/test-specs.yml
@@ -14,6 +14,7 @@ scenarios:
       # Ensure initcontainer was attached by operator
       - kubectl get pods --output yaml | yq '.items[].spec.initContainers[].name' | grep -q "nri-nodejs--test-app-nodejs" || { echo -e "===== Operator failed to attach initcontainer. =====" >&2; exit 1; }
       # Send traffic to test app to generate transactions
+      - sleep 10
       - curl --fail-with-body $(minikube service test-app-nodejs-service --url -n default)
     tests:
       nrqls:


### PR DESCRIPTION
# Overview

* Tests on `NodeJS 24 - Arm64` are failing consistently due to timeouts. Allow application an additional 10 seconds after starting to ensure emulated Arm runs can start up in time.