### PR TITLE
feat: Add Windows init containers for .NET.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,11 @@
 
 # Team based ownership
 /.github/workflows/dotnet.yml @newrelic/dotnet
+/.github/workflows/publish-windows.yml @newrelic/dotnet
+/.github/workflows/test-dotnet-windows.yml @newrelic/dotnet
 /src/dotnet/ @newrelic/dotnet
 /tests/dotnet/ @newrelic/dotnet
+/src/dotnet-windows/ @newrelic/dotnet
 
 /.github/workflows/java.yml @newrelic/java
 /src/java/ @newrelic/java

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,7 +73,7 @@ jobs:
       TARGETARCH: 2025
 
   publish-windows2022:
-    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
+    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
     needs: test-dotnet-windows2022
     uses: ./.github/workflows/publish-windows.yml
     secrets: inherit
@@ -82,7 +82,7 @@ jobs:
       TARGETARCH: 2022
 
   publish-windows2025:
-    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
+    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
     needs: test-dotnet-windows2025
     uses: ./.github/workflows/publish-windows.yml
     secrets: inherit

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,9 +16,9 @@ on:
       - 'tests/dotnet/**'
       - '.github/workflows/dotnet.yml'
       - '.github/workflows/publish.yml'
-      - '.github\workflows\publish-windows.yml'
+      - '.github/workflows/publish-windows.yml'
       - '.github/workflows/test.yml'
-      - '.github\workflows\test-dotnet-windows.yml'
+      - '.github/workflows/test-dotnet-windows.yml'
       - '.github/actions/**'
   push:
     paths:
@@ -27,9 +27,9 @@ on:
       - 'tests/dotnet/**'
       - '.github/workflows/dotnet.yml'
       - '.github/workflows/publish.yml'
-      - '.github\workflows\publish-windows.yml'
+      - '.github/workflows/publish-windows.yml'
       - '.github/workflows/test.yml'
-      - '.github\workflows\test-dotnet-windows.yml'
+      - '.github/workflows/test-dotnet-windows.yml'
       - '.github/actions/**'
     branches:
       - main

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,3 +55,38 @@ jobs:
     with:
       INITCONTAINER_LANGUAGE: dotnet
       ARCHITECTURE: linux/amd64,linux/arm64
+
+  # publish-windows,yml cannot runs the usual tests since it relies on minikube which does not support Windows pods.
+
+  test-dotnet-windows2022:
+    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
+    uses: ./.github/workflows/test-dotnet-windows.yml
+    secrets: inherit
+    with:
+      TARGETARCH: 2022
+
+  test-dotnet-windows2025:
+    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
+    uses: ./.github/workflows/test-dotnet-windows.yml
+    secrets: inherit
+    with:
+      TARGETARCH: 2025
+
+  publish-windows2022:
+    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
+    needs: test-dotnet-windows2022
+    uses: ./.github/workflows/publish-windows.yml
+    secrets: inherit
+    with:
+      INITCONTAINER_LANGUAGE: dotnet-windows
+      TARGETARCH: 2022
+
+  publish-windows2025:
+    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
+    needs: test-dotnet-windows2025
+    uses: ./.github/workflows/publish-windows.yml
+    secrets: inherit
+    with:
+      INITCONTAINER_LANGUAGE: dotnet-windows
+      TARGETARCH: 2025
+    

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,18 +12,24 @@ on:
   pull_request:
     paths:
       - 'src/dotnet/**'
+      - 'src/dotnet-windows/**'
       - 'tests/dotnet/**'
       - '.github/workflows/dotnet.yml'
       - '.github/workflows/publish.yml'
+      - '.github\workflows\publish-windows.yml'
       - '.github/workflows/test.yml'
+      - '.github\workflows\test-dotnet-windows.yml'
       - '.github/actions/**'
   push:
     paths:
       - 'src/dotnet/**'
+      - 'src/dotnet-windows/**'
       - 'tests/dotnet/**'
       - '.github/workflows/dotnet.yml'
       - '.github/workflows/publish.yml'
+      - '.github\workflows\publish-windows.yml'
       - '.github/workflows/test.yml'
+      - '.github\workflows\test-dotnet-windows.yml'
       - '.github/actions/**'
     branches:
       - main
@@ -73,7 +79,7 @@ jobs:
       TARGETARCH: 2025
 
   publish-windows2022:
-    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
+    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
     needs: test-dotnet-windows2022
     uses: ./.github/workflows/publish-windows.yml
     secrets: inherit
@@ -82,7 +88,7 @@ jobs:
       TARGETARCH: 2022
 
   publish-windows2025:
-    if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET
+    if: github.event_name == 'release' && endsWith(github.ref, '_dotnet') # Skip everything if this isn't .NET
     needs: test-dotnet-windows2025
     uses: ./.github/workflows/publish-windows.yml
     secrets: inherit

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -1,0 +1,107 @@
+# Copyright New Relic, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+  name: Windows Init Container Publish
+  
+  on:
+    workflow_call:
+      inputs:
+        INITCONTAINER_LANGUAGE:
+          required: true
+          type: string
+        TARGETARCH:
+          description: "Target Windows architecture for the build (e.g. 2022, 2025)"
+          required: true
+          type: string
+        DOCKER_IMAGE_NAME:
+          description: "Name for the published docker image, defaults to newrelic/newrelic-<INITCONTAINER_LANGUAGE>-init"
+          required: false
+          type: string
+          default: ""
+        DOCKER_IMAGE_TAG_SUFFIX:
+          description: "Suffix to append to all version tags. (string with no preceding -)"
+          required: false
+          type: string
+          default: ""
+        DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX:
+          description: "Boolean indicating if both suffixed and non-suffixed tags should be produced. (true|false)"
+          required: false
+          type: boolean
+          default: false
+  
+  # Declare default permissions as read only.
+  permissions: read-all
+  
+  jobs:
+    publish:
+      runs-on: windows-2025
+  
+      steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+          with:
+            disable-sudo: true
+            egress-policy: audit
+  
+        - name: Checkout code
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+  
+        - name: Extract Agent Version Tags
+          id: version
+          uses: ./.github/actions/extract_agent_version_tags
+          with:
+            tag_suffix: ${{ inputs.DOCKER_IMAGE_TAG_SUFFIX }}
+            is_default_suffix: ${{ inputs.DOCKER_IMAGE_TAG_IS_DEFAULT_SUFFIX }}
+  
+        - name: Generate Docker metadata (tags and labels)
+          id: meta
+          uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # 5.8.0
+          with:
+            images: ${{ inputs.DOCKER_IMAGE_NAME || format('newrelic/newrelic-{1}{2}-init', inputs.INITCONTAINER_LANGUAGE, inputs.TARGETARCH) }}
+            flavor: |
+              latest=false
+            tags: ${{ steps.version.outputs.tags }}
+  
+        - name: Login to Docker Hub Container Registry
+          uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # 3.5.0
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_TOKEN }}
+  
+        # Used to avoid issues with powershell variable expansion in the build step
+        - name: Prepare Labels
+          id: prep_labels
+          run: |
+            foreach ($label in ($env:DOCKER_METADATA_OUTPUT_LABELS -split "`n")) {
+              if ($label -ne "") {
+                if ($label[-1] -eq "=") {
+                  $label = $label.Substring(0, $label.Length - 1)
+                }
+  
+                $env:LABELS=$env:LABELS + " --label $label"
+              }
+            }
+  
+            $env:LABELS=$env:LABELS.TrimStart()
+            Write-Output "labels=$($env:LABELS)" >> $Env:GITHUB_OUTPUT
+  
+        - name: Build and publish init container image
+          run: |
+            cd src/${{ inputs.INITCONTAINER_LANGUAGE }}/
+  
+            # Build container
+            $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', inputs.INITCONTAINER_LANGUAGE, inputs.TARGETARCH) }}:latest"
+            
+            Write-Host "docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME ."
+            docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME .
+  
+            # tag container
+            foreach ($tag in ($env:DOCKER_METADATA_OUTPUT_TAGS -split "`n")) {
+              if ($tag -ne "") {
+                docker tag $env:IMAGE_NAME $tag
+              }
+            }
+  
+            # push container with all tags
+            docker image push --all-tags ${{ format('newrelic/newrelic-{1}{2}-init', inputs.INITCONTAINER_LANGUAGE, inputs.TARGETARCH) }}
+  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # Copyright New Relic, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: Init Container Publish
+name: Linux Init Container Publish
 
 on:
   workflow_call:

--- a/.github/workflows/test-dotnet-windows.yml
+++ b/.github/workflows/test-dotnet-windows.yml
@@ -1,0 +1,86 @@
+# Copyright New Relic, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Windows Init Container Test
+
+on:
+  workflow_call:
+    inputs:
+      TARGETARCH:
+        description: "Target Windows architecture for the build (e.g. 2022, 2025)"
+        required: true
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  test:
+    name: Run basic tests for .NET on Windows ${{ inputs.TARGETARCH }}
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
+        with:
+          persist-credentials: false
+
+      # Gives higher rate limits for image pulls
+      - name: Login to Docker Hub Container Registry (Read Only)
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # 3.5.0
+        # skip login for workflows triggered by Dependabot 
+        if: github.actor != 'dependabot[bot]' 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_READ_ONLY }}
+
+      - name: Extract Agent Version from Release Tag
+        id: version
+        if: github.event_name == 'release'
+        run: |
+          $refName = "${{ github.ref_name }}"
+          $agentVersion = $refName -replace '^v', '' -replace '_[a-zA-Z]*', '' -replace '\.[0-9]*$', ''
+          "AGENT_VERSION=$agentVersion" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Build and init container image
+        run: |
+          cd src/dotnet-windows
+
+          # Build container
+          $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', 'dotnet-windows', inputs.TARGETARCH) }}:latest"
+          
+          Write-Host "docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME ."
+          docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME .
+
+      # Not meant to be exhaustive, just a basic check that the image was built correctly
+      - name: Run basic tests
+        env:
+          FILES_TO_CHECK: |
+            C:\instrumentation\agentinfo.json
+            C:\instrumentation\netcore\agentinfo.json
+            C:\instrumentation\netframework\agentinfo.json
+            C:\instrumentation\LICENSE.txt
+            C:\instrumentation\README.md
+            C:\instrumentation\THIRD_PARTY_NOTICES.txt
+            C:\instrumentation\netcore\newrelic.config
+            C:\instrumentation\netcore\NewRelic.Profiler.dll
+            C:\instrumentation\netcore\extensions\extension.xsd
+            C:\instrumentation\netcore\extensions\NewRelic.Providers.Wrapper.AspNetCore.dll
+            C:\instrumentation\netcore\extensions\NewRelic.Providers.Wrapper.AspNetCore.Instrumentation.xml
+            C:\instrumentation\netframework\newrelic.config
+            C:\instrumentation\netframework\NewRelic.Profiler.dll
+            C:\instrumentation\netframework\extensions\extension.xsd
+            C:\instrumentation\netframework\extensions\NewRelic.Providers.Wrapper.AspNet.dll
+            C:\instrumentation\netframework\extensions\NewRelic.Providers.Wrapper.AspNet.Instrumentation.xml
+        run: |
+          # Basic test to ensure the image was built correctly
+          $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', 'dotnet-windows', inputs.TARGETARCH) }}:latest"
+
+          Write-Host "Running container $env:IMAGE_NAME"
+
+          $files = $env:FILES_TO_CHECK.Trim() -split '\s+'
+          $command = ($files | ForEach-Object { "dir $_" }) -join ' && '
+
+          # Checks if each file exists and the docker command succeeds if they do
+          Write-Host "Running command in container: $command"
+          docker run --rm --entrypoint cmd $env:IMAGE_NAME /c "$command"

--- a/.github/workflows/test-dotnet-windows.yml
+++ b/.github/workflows/test-dotnet-windows.yml
@@ -18,6 +18,8 @@ jobs:
   test:
     name: Run basic tests for .NET on Windows ${{ inputs.TARGETARCH }}
     runs-on: windows-2025
+    env:
+      AGENT_VERSION: latest
 
     steps:
       - name: Checkout code
@@ -48,7 +50,7 @@ jobs:
 
           # Build container
           $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', 'dotnet-windows', inputs.TARGETARCH) }}:latest"
-          
+
           Write-Host "docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME ."
           docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME .
 

--- a/src/dotnet-windows/Dockerfile
+++ b/src/dotnet-windows/Dockerfile
@@ -15,14 +15,14 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:f49449a998f8ba4b1bd5b0
 # Set the working directory
 WORKDIR C:\\instrumentation
 
-# Copy batch script to image
+# Copy batch script to image to root of C:
 COPY dotnet-agent-download.cmd /
 
 # Argument to specify the version of the New Relic agent
 ARG AGENT_VERSION="latest"
 
 # Download and extract the New Relic .NET agent using command prompt's curl.exe
-RUN c:\dotnet-agent-download.cmd %AGENT_VERSION% || exit 1
+RUN C:\\dotnet-agent-download.cmd %AGENT_VERSION% || exit 1
 
 COPY agentinfo.json .
 COPY agentinfo.json .\\netcore\\agentinfo.json

--- a/src/dotnet-windows/Dockerfile
+++ b/src/dotnet-windows/Dockerfile
@@ -15,13 +15,14 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:f49449a998f8ba4b1bd5b0
 # Set the working directory
 WORKDIR C:\\instrumentation
 
+# Copy batch script to image
+COPY dotnet-agent-download.cmd /
+
 # Argument to specify the version of the New Relic agent
-ARG AGENT_VERSION
+ARG AGENT_VERSION="latest"
 
 # Download and extract the New Relic .NET agent using command prompt's curl.exe
-RUN curl.exe -L -o newrelic-agent.zip https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_%AGENT_VERSION%_x64.zip \
-    && tar.exe -xzf newrelic-agent.zip \
-    && del newrelic-agent.zip
+RUN c:\dotnet-agent-download.cmd %AGENT_VERSION% || exit 1
 
 COPY agentinfo.json .
 COPY agentinfo.json .\\netcore\\agentinfo.json

--- a/src/dotnet-windows/Dockerfile
+++ b/src/dotnet-windows/Dockerfile
@@ -1,0 +1,33 @@
+# To build one auto-instrumentation image for dotnet, please:
+#  - Download the newrelic dotnet artifacts to `/instrumentation` directory. This is required as when instrumenting the pod,
+#    one init container will be created to copy the files to your app's container.
+#  - Following environment variables are injected to the application container to enable the auto-instrumentation.
+#    https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables
+#    https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-core-env-variables
+
+# This container needs to match the target architecture.
+# Valid TARGETARCH: ltsc2022, ltsc2025
+ARG TARGETARCH
+
+# This container can be pinned to latest OS since all it does is get the data which is OS agnostic.
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:f49449a998f8ba4b1bd5b00c2fbd0b7a34bf9471078f5d79b80db34be5833398 as build
+
+# Set the working directory
+WORKDIR C:\\instrumentation
+
+# Argument to specify the version of the New Relic agent
+ARG AGENT_VERSION
+
+# Download and extract the New Relic .NET agent using command prompt's curl.exe
+RUN curl.exe -L -o newrelic-agent.zip https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_%AGENT_VERSION%_x64.zip \
+    && tar.exe -xzf newrelic-agent.zip \
+    && del newrelic-agent.zip
+
+COPY agentinfo.json .
+COPY agentinfo.json .\\netcore\\agentinfo.json
+COPY agentinfo.json .\\netframework\\agentinfo.json
+
+# This container needs to match the target architecture.
+FROM mcr.microsoft.com/windows/nanoserver:ltsc${TARGETARCH}
+
+COPY --from=build /instrumentation /instrumentation

--- a/src/dotnet-windows/agentinfo.json
+++ b/src/dotnet-windows/agentinfo.json
@@ -1,0 +1,3 @@
+{
+    "install_type": "k8s-operator"
+}

--- a/src/dotnet-windows/dotnet-agent-download.cmd
+++ b/src/dotnet-windows/dotnet-agent-download.cmd
@@ -1,0 +1,12 @@
+@echo off
+
+set AGENT_VERSION=%1
+
+if "%AGENT_VERSION%"=="latest" (
+    curl.exe -L -o newrelic-agent.zip https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.zip
+) else (
+    curl.exe -L -o newrelic-agent.zip https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_%AGENT_VERSION%_x64.zip
+)
+
+tar.exe -xzf newrelic-agent.zip || exit /b 1
+del newrelic-agent.zip


### PR DESCRIPTION
- Adds init containers for the .NET Agent running on Windows 2022 and Windows 2025.
- Windows requires that the OS match container (for the most part), we need two images.
- Uses existing dotnet.yml workflow,
- Uses a manual docker build and push since the buildx installer does not support windows.
- Doesn't use the existing tests since those require minikube which does not support Windows containers.
- New tests just for .NET on Windows have been added that validate the images build, run, and contain the correct files (not an exhaustive check.)