### PR TITLE
Drop Python Version 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         architecture: ["linux/amd64", "linux/arm64"]
     with:
       INITCONTAINER_LANGUAGE: python

--- a/src/python/requirements-vendor.txt
+++ b/src/python/requirements-vendor.txt
@@ -1,1 +1,1 @@
-pip==24.0  # Last supported version for Python 3.7
+pip==25.0.1  # Last supported version for Python 3.8


### PR DESCRIPTION
## Overview

* Drop support for Python 3.7 in line with new agent version `v11.0.0`.