### PR TITLE
Use real ARM64 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ permissions: read-all
 jobs:
   test:
     name: Run E2E tests for ${{ inputs.INITCONTAINER_LANGUAGE }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ startsWith(inputs.ARCHITECTURE, 'linux/arm') && 'ubuntu-latest-arm' || 'ubuntu-latest'}}
     env:
       TEST_APP_HELM_CHART_ARGS: ${{ inputs.TEST_APP_HELM_CHART_ARGS }}
 
@@ -51,13 +51,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN_READ_ONLY }}
-
-      - name: Enable arm64 emulation
-        if: inputs.ARCHITECTURE != 'linux/amd64'
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # 3.6.0
-        with:
-          image: tonistiigi/binfmt:qemu-v6.2.0
-          platforms: ${{ inputs.ARCHITECTURE }}
 
       - name: Extract Agent Version from Release Tag
         id: version


### PR DESCRIPTION
## Overview

* Testing using real ARM64 runners instead of emulation to speed up the CI.